### PR TITLE
解决部分音乐无法下载抛出错误问题，添加自动复制重命名MP3的逻辑。

### DIFF
--- a/down.py
+++ b/down.py
@@ -1,6 +1,7 @@
 import os
 
 import requests
+import shutil
 
 download_proxies = {
     'http': '',
@@ -34,6 +35,9 @@ def download_file(songs_info, download_dir):
 
     verify = verify_file(download_dir, songs_info)
     songs_info['download_verify'] = verify
+    song_path = os.path.join(download_dir, songs_info['download_path'])
+    target_path = os.path.join(download_dir, '{0}-{1}.mp3'.format(songs_info['songname'], songs_info['signernames']))
+    shutil.copy(song_path, target_path)
     return verify
 
 
@@ -47,4 +51,6 @@ def verify_file(down_dir, songs_info):
     if size != songs_info['filesize']:
         return False
     else:
+        target_path = os.path.join(down_dir, '{0}-{1}.mp3'.format(songs_info['songname'], songs_info['signernames']))
+        shutil.copy(song_path, target_path)
         return True

--- a/sixyin.py
+++ b/sixyin.py
@@ -89,9 +89,12 @@ def get_download_link(song_info, music_dir, key):
     if result['code'] == 400:
         return None
     else:
-        song_info['download_link'] = result['data'][0]
-
-        return song_info['download_link']
+        if ('data' in result.keys()):
+            song_info['download_link'] = result['data'][0]
+            return song_info['download_link']
+        else:
+            song_info['download_response'] = result
+            return None
 
 
 def reset_verify_failed_songs_info(songs_info):


### PR DESCRIPTION
有时会返回以下内容，做一下错误处理。另外根据下载内容生成MP3格式的文件。
```
{
    "code": 500,
    "msg": "服务器异常",
    "timestamp": 0
}
```